### PR TITLE
[FIX] vapor-ui/icons 참조 수정

### DIFF
--- a/frontend/components/DuplicateLoginModal.js
+++ b/frontend/components/DuplicateLoginModal.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { WarningIcon, TimeIcon, ExternalLinkIcon } from '@vapor-ui/icons';
+import { WarningIcon, TimeIcon, LinkOutlineIcon as ExternalLinkIcon } from '@vapor-ui/icons';
 import { Button, Text, Callout } from '@vapor-ui/core';
 
 const DuplicateLoginModal = ({ 

--- a/frontend/components/chat/FilePreview.js
+++ b/frontend/components/chat/FilePreview.js
@@ -6,7 +6,7 @@ import {
   PdfIcon as FileText, 
   MovieIcon as Film, 
   LoadingOutlineIcon as Loader,
-  MusicIcon as Music,
+  SoundOnIcon as Music,
   FileIcon as File
 } from '@vapor-ui/icons';
 import { Button, IconButton, Callout } from '@vapor-ui/core';

--- a/frontend/components/chat/Message/FileMessage.js
+++ b/frontend/components/chat/Message/FileMessage.js
@@ -5,8 +5,8 @@ import {
   MovieIcon as Film, 
   CorrectOutlineIcon as CheckCheck, 
   CorrectOutlineIcon as Check, 
-  MusicIcon as Music, 
-  ExternalLinkIcon as ExternalLink, 
+  SoundOnIcon as Music, 
+  LinkOutlineIcon as ExternalLink, 
   DownloadIcon as Download,
   ErrorCircleIcon as AlertCircle 
 } from '@vapor-ui/icons';


### PR DESCRIPTION
## Bug

<img width="1039" height="262" alt="image" src="https://github.com/user-attachments/assets/eca50998-0731-4f73-b2ec-f7fc1f39bac7" />

- import 오류: vapor-icons/ui의 존재하지 않는 아이콘 참조

## Fix

- `ExternalLinkIcon` -> `LinkOutlineIcon`
- `MusicIccon` -> `SoundOnIcon`