### PR TITLE
feat: Redis 캐싱을 통한 채팅 메시지 조회 성능 개선

### DIFF
--- a/backend/routes/api/status.js
+++ b/backend/routes/api/status.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { getCacheStats } = require('../../services/redisMessageService'); // 경로는 현재 위치에 따라 조정
+
+// 캐시 상태 확인용 API
+router.get('/cache', async (req, res) => {
+  try {
+    const stats = await getCacheStats();
+    res.json({
+      success: true,
+      data: stats
+    });
+  } catch (error) {
+    console.error('캐시 상태 조회 에러:', error);
+    res.status(500).json({
+      success: false,
+      message: '캐시 상태 조회에 실패했습니다.',
+      error: error.message
+    });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ const socketIO = require('socket.io');
 const path = require('path');
 const { router: roomsRouter, initializeSocket } = require('./routes/api/rooms');
 const routes = require('./routes');
+const statusRouter = require('./routes/api/status');
 
 const app = express();
 const server = http.createServer(app);
@@ -69,6 +70,9 @@ app.get('/health', (req, res) => {
     env: process.env.NODE_ENV
   });
 });
+
+// 상태 확인용 라우트
+app.use('/api/status', statusRouter);
 
 // API 라우트 마운트
 app.use('/api', routes);

--- a/backend/services/redisMessageService.js
+++ b/backend/services/redisMessageService.js
@@ -1,0 +1,94 @@
+const redisClient = require('../utils/redisClient');
+const Message = require('../models/Message');
+
+const MESSAGE_KEY_PREFIX = 'chat:room';
+const REDIS_MESSAGE_LIMIT = 90; // Redis에 저장할 메시지 개수
+const REDIS_TTL_SECONDS = 3600; // Redis에 저장할 메시지 TTL (초)
+
+const getMessageKey = (roomId) => `${MESSAGE_KEY_PREFIX}:${roomId}:messages`;
+
+const saveMessageToRedis = async (roomId, messageObj) => {
+  const key = getMessageKey(roomId);
+  await redisClient.connect();
+
+  const pipeline = redisClient.client.multi();
+  pipeline.lPush(key, JSON.stringify(messageObj));
+  pipeline.lTrim(key, 0, REDIS_MESSAGE_LIMIT - 1);
+  pipeline.expire(key, REDIS_TTL_SECONDS);
+  await pipeline.exec();
+};
+
+const getCachedMessages = async (roomId) => {
+  const key = getMessageKey(roomId);
+
+  await redisClient.connect(); // 연결 보장
+
+  const cached = await redisClient.client.lRange(key, 0, -1);
+  const messages = cached.map(msg => JSON.parse(msg));
+
+  if (messages.length > 0) {
+    await incrementCacheHit(); // ✅ 실제로 가져온 메시지가 있을 때만 hit 증가
+  } else {
+    await incrementCacheMiss(); // ✅ 없을 경우 miss 증가
+  }
+
+  return messages;
+};
+
+const incrementCacheHit = async () => {
+  await redisClient.client.incr('chat:cache:hit');
+};
+
+const incrementCacheMiss = async () => {
+  await redisClient.client.incr('chat:cache:miss');
+};
+
+const getCacheStats = async () => {
+  await redisClient.connect(); // 연결 보장
+  
+  const [hit, miss] = await redisClient.client.mGet([
+    'chat:cache:hit',
+    'chat:cache:miss'
+  ]);
+  const hitCount = parseInt(hit || '0', 10);
+  const missCount = parseInt(miss || '0', 10);
+  const total = hitCount + missCount;
+  const hitRate = total > 0 ? ((hitCount / total) * 100).toFixed(2) : '0.00';
+
+  return {
+    hit: hitCount,
+    miss: missCount,
+    hitRate: `${hitRate}%`
+  };
+};
+
+const ensureRedisWarmup = async (roomId) => {
+  const key = getMessageKey(roomId);
+
+  await redisClient.connect(); // 연결 보장
+
+  const exists = await redisClient.client.exists(key);
+  if (!exists) {
+    const messages = await Message.find({ room: roomId })
+      .sort({ timestamp: -1 })
+      .limit(REDIS_MESSAGE_LIMIT)
+      .lean();
+
+    for (const msg of messages.reverse()) {
+      await redisClient.client.rPush(key, JSON.stringify(msg));
+    }
+    await redisClient.expire(key, REDIS_TTL_SECONDS);
+  }
+};
+
+const isCacheFull = (cachedMessages) => {
+  return cachedMessages.length === REDIS_MESSAGE_LIMIT;
+};
+
+module.exports = {
+  saveMessageToRedis,
+  getCachedMessages,
+  ensureRedisWarmup,
+  isCacheFull,
+  getCacheStats
+};

--- a/chat-server/routes/api/status.js
+++ b/chat-server/routes/api/status.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const { getCacheStats } = require('../../services/redisMessageService'); // 경로는 현재 위치에 따라 조정
+
+// 캐시 상태 확인용 API
+router.get('/cache', async (req, res) => {
+  try {
+    const stats = await getCacheStats();
+    res.json({
+      success: true,
+      data: stats
+    });
+  } catch (error) {
+    console.error('캐시 상태 조회 에러:', error);
+    res.status(500).json({
+      success: false,
+      message: '캐시 상태 조회에 실패했습니다.',
+      error: error.message
+    });
+  }
+});
+
+module.exports = router;

--- a/chat-server/server.js
+++ b/chat-server/server.js
@@ -7,6 +7,7 @@ const socketIO = require('socket.io');
 const path = require('path');
 const { router: roomsRouter, initializeSocket } = require('./routes/api/rooms');
 const routes = require('./routes');
+const statusRouter = require('./routes/api/status');
 
 const app = express();
 const server = http.createServer(app);
@@ -69,6 +70,9 @@ app.get('/health', (req, res) => {
     env: process.env.NODE_ENV
   });
 });
+
+// 상태 확인용 라우트
+app.use('/api/status', statusRouter);
 
 // API 라우트 마운트
 app.use('/api', routes);

--- a/chat-server/services/redisMessageService.js
+++ b/chat-server/services/redisMessageService.js
@@ -1,0 +1,94 @@
+const redisClient = require('../utils/redisClient');
+const Message = require('../models/Message');
+
+const MESSAGE_KEY_PREFIX = 'chat:room';
+const REDIS_MESSAGE_LIMIT = 90; // Redis에 저장할 메시지 개수
+const REDIS_TTL_SECONDS = 3600; // Redis에 저장할 메시지 TTL (초)
+
+const getMessageKey = (roomId) => `${MESSAGE_KEY_PREFIX}:${roomId}:messages`;
+
+const saveMessageToRedis = async (roomId, messageObj) => {
+  const key = getMessageKey(roomId);
+  await redisClient.connect();
+
+  const pipeline = redisClient.client.multi();
+  pipeline.lPush(key, JSON.stringify(messageObj));
+  pipeline.lTrim(key, 0, REDIS_MESSAGE_LIMIT - 1);
+  pipeline.expire(key, REDIS_TTL_SECONDS);
+  await pipeline.exec();
+};
+
+const getCachedMessages = async (roomId) => {
+  const key = getMessageKey(roomId);
+
+  await redisClient.connect(); // 연결 보장
+
+  const cached = await redisClient.client.lRange(key, 0, -1);
+  const messages = cached.map(msg => JSON.parse(msg));
+
+  if (messages.length > 0) {
+    await incrementCacheHit(); // ✅ 실제로 가져온 메시지가 있을 때만 hit 증가
+  } else {
+    await incrementCacheMiss(); // ✅ 없을 경우 miss 증가
+  }
+
+  return messages;
+};
+
+const incrementCacheHit = async () => {
+  await redisClient.client.incr('chat:cache:hit');
+};
+
+const incrementCacheMiss = async () => {
+  await redisClient.client.incr('chat:cache:miss');
+};
+
+const getCacheStats = async () => {
+  await redisClient.connect(); // 연결 보장
+  
+  const [hit, miss] = await redisClient.client.mGet([
+    'chat:cache:hit',
+    'chat:cache:miss'
+  ]);
+  const hitCount = parseInt(hit || '0', 10);
+  const missCount = parseInt(miss || '0', 10);
+  const total = hitCount + missCount;
+  const hitRate = total > 0 ? ((hitCount / total) * 100).toFixed(2) : '0.00';
+
+  return {
+    hit: hitCount,
+    miss: missCount,
+    hitRate: `${hitRate}%`
+  };
+};
+
+const ensureRedisWarmup = async (roomId) => {
+  const key = getMessageKey(roomId);
+
+  await redisClient.connect(); // 연결 보장
+
+  const exists = await redisClient.client.exists(key);
+  if (!exists) {
+    const messages = await Message.find({ room: roomId })
+      .sort({ timestamp: -1 })
+      .limit(REDIS_MESSAGE_LIMIT)
+      .lean();
+
+    for (const msg of messages.reverse()) {
+      await redisClient.client.rPush(key, JSON.stringify(msg));
+    }
+    await redisClient.expire(key, REDIS_TTL_SECONDS);
+  }
+};
+
+const isCacheFull = (cachedMessages) => {
+  return cachedMessages.length === REDIS_MESSAGE_LIMIT;
+};
+
+module.exports = {
+  saveMessageToRedis,
+  getCachedMessages,
+  ensureRedisWarmup,
+  isCacheFull,
+  getCacheStats
+};


### PR DESCRIPTION
### 개요
채팅방 입장 시 메시지 조회 성능을 개선하기 위해 Redis 기반 캐싱을 도입하였습니다. 최신 메시지 최대 90개를 Redis에 저장하고, 캐시 miss 시 MongoDB에서 조회 후 warm-up 하도록 구성하였습니다.

### ✨ 주요 변경사항
Redis에 채팅방별 메시지 리스트 캐싱 (chat:room:{roomId}:messages)
`saveMessageToRedis`, `getCachedMessages`, `ensureRedisWarmup` 함수 구현
Redis TTL 적용 및 LRU 정책 병행
Redis 캐시 통계 기능 추가 (hit/miss, hit rate 계산)
Redis 캐시 상태 확인 API 추가: `GET /api/status/cache`

### 메시지 처리 흐름 
1. 채팅방 입장
    - Redis 조회 (cache hit 시 바로 메시지 전달)
    - cache miss 시 MongoDB에서 조회 후 Redis warm-up
2. 메시지 전송
    - MongoDB 저장 후 Redis에 LPUSH + LTRIM 캐싱 동기화

### 추가 설정 및 고려 사항
- 캐시 메시지 수: 90개 (배치 크기 30의 3배)
- TTL: 1시간
- 추후 관리자용 통계 UI에 hit rate 시각화 연동 고려

- `/api/status/cache` 로 상태확인 요청 시,
<img width="243" height="99" alt="image" src="https://github.com/user-attachments/assets/b1c0c7cd-adc3-4724-bc3a-3726baad02d9" />
