### PR TITLE
[FIX] 채팅 마크다운 입출력 버그 해결

### DIFF
--- a/frontend/components/chat/ChatInput.js
+++ b/frontend/components/chat/ChatInput.js
@@ -342,8 +342,9 @@ const ChatInput = forwardRef(({
         default:
           return;
       }
-    } else if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      e.preventDefault();
+    } else if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.nativeEvent.isComposing) return
+        e.preventDefault();
       if (message.trim() || files.length > 0) {
         handleSubmit(e);
       }
@@ -366,63 +367,70 @@ const ChatInput = forwardRef(({
   ]);
 
   const handleMarkdownAction = useCallback((markdown) => {
-    if (!messageInputRef?.current) return;
+  if (!messageInputRef?.current) return;
 
-    const input = messageInputRef.current;
-    const start = input.selectionStart;
-    const end = input.selectionEnd;
-    const selectedText = message.substring(start, end);
-    let newText;
-    let newCursorPos;
-    let newSelectionStart;
-    let newSelectionEnd;
+  const input = messageInputRef.current;
+  const start = input.selectionStart;
+  const end = input.selectionEnd;
+  const selectedText = message.substring(start, end);
+  let newText;
+  let newCursorPos;
+  let newSelectionStart;
+  let newSelectionEnd;
 
-    if (markdown.includes('\n')) {
-      newText = message.substring(0, start) +
-                markdown.replace('\n\n', '\n' + selectedText + '\n') +
-                message.substring(end);
-      if (selectedText) {
-        newSelectionStart = start + markdown.split('\n')[0].length + 1;
-        newSelectionEnd = newSelectionStart + selectedText.length;
-        newCursorPos = newSelectionEnd;
-      } else {
-        newCursorPos = start + markdown.indexOf('\n') + 1;
-        newSelectionStart = newCursorPos;
-        newSelectionEnd = newCursorPos;
-      }
-    } else if (markdown.endsWith(' ')) {
-      newText = message.substring(0, start) +
-                markdown + selectedText +
-                message.substring(end);
-      newCursorPos = start + markdown.length + selectedText.length;
+  if (markdown === '[](url)') {
+    newText = message.substring(0, start) + '[](url)' + message.substring(end);
+    newSelectionStart = start + 1; 
+    newSelectionEnd = newSelectionStart;
+    newCursorPos = newSelectionStart;
+
+  } else if (markdown.includes('\n')) {
+    newText = message.substring(0, start) +
+              markdown.replace('\n\n', '\n' + selectedText + '\n') +
+              message.substring(end);
+    if (selectedText) {
+      newSelectionStart = start + markdown.split('\n')[0].length + 1;
+      newSelectionEnd = newSelectionStart + selectedText.length;
+      newCursorPos = newSelectionEnd;
+    } else {
+      newCursorPos = start + markdown.indexOf('\n') + 1;
       newSelectionStart = newCursorPos;
       newSelectionEnd = newCursorPos;
-    } else {
-      newText = message.substring(0, start) +
-                markdown + selectedText + markdown +
-                message.substring(end);
-      if (selectedText) {
-        newSelectionStart = start + markdown.length;
-        newSelectionEnd = newSelectionStart + selectedText.length;
-      } else {
-        newSelectionStart = start + markdown.length;
-        newSelectionEnd = newSelectionStart;
-      }
-      newCursorPos = newSelectionEnd;
     }
+  } else if (markdown.endsWith(' ')) {
+    newText = message.substring(0, start) +
+              markdown + selectedText +
+              message.substring(end);
+    newCursorPos = start + markdown.length + selectedText.length;
+    newSelectionStart = newCursorPos;
+    newSelectionEnd = newCursorPos;
+  } else {
+    newText = message.substring(0, start) +
+              markdown + selectedText + markdown +
+              message.substring(end);
+    if (selectedText) {
+      newSelectionStart = start + markdown.length;
+      newSelectionEnd = newSelectionStart + selectedText.length;
+    } else {
+      newSelectionStart = start + markdown.length;
+      newSelectionEnd = newSelectionStart;
+    }
+    newCursorPos = newSelectionEnd;
+  }
 
-    setMessage(newText);
+  setMessage(newText);
 
-    setTimeout(() => {
-      if (messageInputRef.current) {
-        input.focus();
-        input.setSelectionRange(newSelectionStart, newSelectionEnd);
-        if (selectedText) {
-          input.setSelectionRange(newCursorPos, newCursorPos);
-        }
+  setTimeout(() => {
+    if (messageInputRef.current) {
+      input.focus();
+      input.setSelectionRange(newSelectionStart, newSelectionEnd);
+      if (selectedText) {
+        input.setSelectionRange(newCursorPos, newCursorPos);
       }
-    }, 0);
-  }, [message, setMessage, messageInputRef]);
+    }
+  }, 0);
+}, [message, setMessage, messageInputRef]);
+
 
   const handleEmojiSelect = useCallback((emoji) => {
     if (!messageInputRef?.current) return;

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -506,6 +506,17 @@ body {
   margin: var(--vapor-space-050) 0;
 }
 
+
+.message-content .md-ul {
+  list-style-type: disc; 
+  list-style-position: outside;
+}
+
+.message-content .md-ol {
+  list-style-type: decimal; 
+  list-style-position: outside;
+}
+
 /* Code blocks */
 .message-content pre[class*="language-"] {
   margin: var(--vapor-space-100) 0;


### PR DESCRIPTION
## 버그
<img width="267" height="71" alt="image" src="https://github.com/user-attachments/assets/e4b458ec-7fca-4562-82fb-8f0dc32a47c5" />

- 링크 버튼 클릭시 입력 형태 두 번씩 출력되는 문제
<img width="400" height="120" alt="image" src="https://github.com/user-attachments/assets/a2a5eaf1-5cf8-46ab-9988-0175810718af" />

- ul, ol의 경우 앞의 불릿이나 숫자 출력 안되는 문제

## 해결
- `ChatInput`의 링크 속성에 대한 조건 추가
- `globals.css`에 ul, ol 관련 스타일 추가